### PR TITLE
Update ddb-dm-screen.user.js

### DIFF
--- a/ddb-dm-screen.user.js
+++ b/ddb-dm-screen.user.js
@@ -74,7 +74,7 @@ const senseToName = {
 
 const scriptVarPrefix = "DMScreen-";
 
-const charIDRegex = /\/(\d+).*?$/;
+const charIDRegex = /characters\/(\d+).*?$/;
 const campaignIDRegex = /\/(\d+)\/*$/;
 
 const FEET_IN_MILES = 5280;


### PR DESCRIPTION
Deduplicated code and fixed a bug:

If a player's username has a number as the first character. Then the character sheet loads with that number's character ID.

Player username "6f6dddfoqijwe" would load character information for characters ID "6", however rest of links work correctly. Temp fix until can work out how the rest of the code pulls the correct character ID for links.
